### PR TITLE
Fix crypt_blowfish lib lookup

### DIFF
--- a/lib/Crypt/Bcrypt.pm6
+++ b/lib/Crypt/Bcrypt.pm6
@@ -13,8 +13,10 @@ file, you can obtain one at http://opensource.org/licenses/isc-license.txt
 sub library returns Str {
 	my $so = get-vars('')<SO>;
 	for @*INC {
-		if ($_~'/crypt_blowfish'~$so).IO ~~ :f {
-			return $_~'/crypt_blowfish'~$so;
+	    my $inc-path = $_.IO.path.subst(/ ['file#' || 'inst#'] /, '');
+	    my $crypt-blowfish-lib-path = $*SPEC.catfile($inc-path, "crypt_blowfish"~$so);
+		if $crypt-blowfish-lib-path.IO ~~ :f {
+			return $crypt-blowfish-lib-path;
 		}
 	}
 	die 'unable to find library crypt_blowfish';


### PR DESCRIPTION
@*INC doesn't contain just a list of paths anymore, it is currently a list
of file# or inst# strings (which are strings of the actual paths, however
with file# or inst# in front; I believe these prefixes are to denote a local
file system location or an installation location).  Thus these paths can't
be found on the filesystem.  The hack used here is to strip the leading
'file#' or 'inst#' strings and use the remaining path to perform the library
lookup in a similar manner to that currently done.  This change makes the
test suite run again.