### PR TITLE
Replace pick(1) with pick

### DIFF
--- a/t/06-random.t
+++ b/t/06-random.t
@@ -17,7 +17,7 @@ $difficulty = %*ENV<MAX_DIFFICULTY>.Int if %*ENV<MAX_DIFFICULTY>.defined;
 
 for (1..50) {
 	my Str $r = rchars();
-	my Int $c = (4..$difficulty).pick(1);
+	my Int $c = (4..$difficulty).pick;
 	my Str $h = Crypt::Bcrypt.hash($r, Crypt::Bcrypt.gensalt($c));
 	is Crypt::Bcrypt.hash($r, $h), $h, 'random hash matches, cost: ' ~ $c;
 


### PR DESCRIPTION
This is because .pick(1) returns a List now, and if one simply wants to pick
one element from an array, then only `.pick` is needed.